### PR TITLE
Fix WCAG AA contrast failures in design tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build
         env:

--- a/src/__tests__/contrast.test.ts
+++ b/src/__tests__/contrast.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * WCAG AA contrast checks for the HiveSight design tokens declared in
+ * `src/app/globals.css`. Each pair below documents a guarantee the design
+ * system makes — drift below the declared minimum fails CI before publish.
+ *
+ * The tokens live in CSS as HSL triplets (`H S% L%`); we resolve them to hex
+ * here so the assertions don't depend on a browser to compute relative
+ * luminance.
+ *
+ * @see https://www.w3.org/TR/WCAG22/#dfn-contrast-ratio
+ */
+
+/** Convert a CSS `H S% L%` triplet to `#rrggbb`. */
+function hslToHex(h: number, s: number, l: number): string {
+  // Standard CSS HSL → RGB conversion.
+  const hue = ((h % 360) + 360) % 360;
+  const sat = s / 100;
+  const lum = l / 100;
+  const c = (1 - Math.abs(2 * lum - 1)) * sat;
+  const hp = hue / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+  if (hp < 1) [r1, g1, b1] = [c, x, 0];
+  else if (hp < 2) [r1, g1, b1] = [x, c, 0];
+  else if (hp < 3) [r1, g1, b1] = [0, c, x];
+  else if (hp < 4) [r1, g1, b1] = [0, x, c];
+  else if (hp < 5) [r1, g1, b1] = [x, 0, c];
+  else [r1, g1, b1] = [c, 0, x];
+  const m = lum - c / 2;
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(r1)}${toHex(g1)}${toHex(b1)}`;
+}
+
+/** WCAG 2.x relative luminance for `#rrggbb`. */
+function relativeLuminance(hex: string): number {
+  const value = hex.replace(/^#/, "");
+  const rgb = [0, 1, 2].map((i) => {
+    const channel = parseInt(value.slice(i * 2, i * 2 + 2), 16) / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+}
+
+/** WCAG contrast ratio between two hex colors. */
+export function contrastRatio(fg: string, bg: string): number {
+  const lFg = relativeLuminance(fg);
+  const lBg = relativeLuminance(bg);
+  const lighter = Math.max(lFg, lBg);
+  const darker = Math.min(lFg, lBg);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Tokens resolved from `src/app/globals.css`. Keep in sync with that file. */
+const lightTokens = {
+  background: hslToHex(40, 33, 99),
+  foreground: hslToHex(30, 10, 12),
+  card: hslToHex(40, 50, 99),
+  cardForeground: hslToHex(30, 10, 12),
+  primary: hslToHex(32, 95, 35),
+  primaryForeground: hslToHex(40, 100, 98),
+  secondary: hslToHex(35, 30, 95),
+  secondaryForeground: hslToHex(30, 10, 15),
+  muted: hslToHex(35, 20, 95),
+  mutedForeground: hslToHex(30, 5, 45),
+  accent: hslToHex(35, 40, 94),
+  accentForeground: hslToHex(30, 10, 15),
+  destructive: hslToHex(0, 73, 49),
+  destructiveForeground: hslToHex(0, 0, 98),
+  border: hslToHex(35, 15, 88),
+  borderStrong: hslToHex(35, 15, 50),
+  ring: hslToHex(32, 95, 35),
+} as const;
+
+const darkTokens = {
+  background: hslToHex(30, 8, 6),
+  foreground: hslToHex(35, 20, 95),
+  card: hslToHex(30, 8, 8),
+  cardForeground: hslToHex(35, 20, 95),
+  primary: hslToHex(38, 92, 50),
+  primaryForeground: hslToHex(30, 10, 8),
+  secondary: hslToHex(30, 8, 14),
+  secondaryForeground: hslToHex(35, 20, 95),
+  muted: hslToHex(30, 8, 14),
+  mutedForeground: hslToHex(30, 8, 55),
+  accent: hslToHex(30, 10, 14),
+  accentForeground: hslToHex(35, 20, 95),
+  destructive: hslToHex(0, 73, 50),
+  destructiveForeground: hslToHex(0, 0, 98),
+  border: hslToHex(30, 8, 18),
+  borderStrong: hslToHex(30, 8, 45),
+  ring: hslToHex(38, 92, 50),
+} as const;
+
+type ContrastPair = {
+  description: string;
+  fg: string;
+  bg: string;
+  /** WCAG SC 1.4.3 normal text: 4.5. SC 1.4.11 non-text (borders, focus
+   * rings, control boundaries): 3.0. */
+  minRatio: number;
+};
+
+const lightPairs: ContrastPair[] = [
+  // Body and surface text
+  {
+    description: "light: foreground on background",
+    fg: lightTokens.foreground,
+    bg: lightTokens.background,
+    minRatio: 4.5,
+  },
+  {
+    description: "light: card-foreground on card",
+    fg: lightTokens.cardForeground,
+    bg: lightTokens.card,
+    minRatio: 4.5,
+  },
+  {
+    description: "light: muted-foreground on background (caption text limit)",
+    fg: lightTokens.mutedForeground,
+    bg: lightTokens.background,
+    minRatio: 4.5,
+  },
+  {
+    description: "light: accent-foreground on accent",
+    fg: lightTokens.accentForeground,
+    bg: lightTokens.accent,
+    minRatio: 4.5,
+  },
+  {
+    description: "light: secondary-foreground on secondary",
+    fg: lightTokens.secondaryForeground,
+    bg: lightTokens.secondary,
+    minRatio: 4.5,
+  },
+  // Brand and status fills
+  {
+    description: "light: primary as text on background (link / status text)",
+    fg: lightTokens.primary,
+    bg: lightTokens.background,
+    minRatio: 4.5,
+  },
+  {
+    description: "light: primary-foreground on primary (button label)",
+    fg: lightTokens.primaryForeground,
+    bg: lightTokens.primary,
+    minRatio: 4.5,
+  },
+  {
+    description: "light: destructive-foreground on destructive (button label)",
+    fg: lightTokens.destructiveForeground,
+    bg: lightTokens.destructive,
+    minRatio: 4.5,
+  },
+  // Non-text per SC 1.4.11
+  {
+    description: "light: border-strong on background (form input border)",
+    fg: lightTokens.borderStrong,
+    bg: lightTokens.background,
+    minRatio: 3.0,
+  },
+  {
+    description: "light: ring on background (focus indicator)",
+    fg: lightTokens.ring,
+    bg: lightTokens.background,
+    minRatio: 3.0,
+  },
+];
+
+const darkPairs: ContrastPair[] = [
+  {
+    description: "dark: foreground on background",
+    fg: darkTokens.foreground,
+    bg: darkTokens.background,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: card-foreground on card",
+    fg: darkTokens.cardForeground,
+    bg: darkTokens.card,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: muted-foreground on background",
+    fg: darkTokens.mutedForeground,
+    bg: darkTokens.background,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: accent-foreground on accent",
+    fg: darkTokens.accentForeground,
+    bg: darkTokens.accent,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: secondary-foreground on secondary",
+    fg: darkTokens.secondaryForeground,
+    bg: darkTokens.secondary,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: primary as text on background (link)",
+    fg: darkTokens.primary,
+    bg: darkTokens.background,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: primary-foreground on primary",
+    fg: darkTokens.primaryForeground,
+    bg: darkTokens.primary,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: destructive-foreground on destructive",
+    fg: darkTokens.destructiveForeground,
+    bg: darkTokens.destructive,
+    minRatio: 4.5,
+  },
+  {
+    description: "dark: destructive on background (SC 1.4.11 surface)",
+    fg: darkTokens.destructive,
+    bg: darkTokens.background,
+    minRatio: 3.0,
+  },
+  {
+    description: "dark: border-strong on background (form input border)",
+    fg: darkTokens.borderStrong,
+    bg: darkTokens.background,
+    minRatio: 3.0,
+  },
+  {
+    description: "dark: ring on background (focus indicator)",
+    fg: darkTokens.ring,
+    bg: darkTokens.background,
+    minRatio: 3.0,
+  },
+];
+
+describe("token contrast", () => {
+  it("contrastRatio matches known WCAG values", () => {
+    // Maximum contrast.
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 0);
+    // Same color always returns 1.
+    expect(contrastRatio("#92400e", "#92400e")).toBeCloseTo(1, 5);
+  });
+
+  it("hslToHex matches a known WCAG-tested value", () => {
+    // amber-700-ish; sanity check the conversion routine.
+    expect(hslToHex(32, 95, 35)).toBe("#ae5f04");
+  });
+
+  it("each light-mode pair clears its declared WCAG minimum", () => {
+    const failures = lightPairs
+      .map((pair) => {
+        const ratio = contrastRatio(pair.fg, pair.bg);
+        return ratio < pair.minRatio
+          ? `${pair.description}: ${pair.fg} on ${pair.bg} = ${ratio.toFixed(
+              2,
+            )}:1 (need ${pair.minRatio.toFixed(1)}:1)`
+          : null;
+      })
+      .filter((m): m is string => m !== null);
+    if (failures.length > 0) {
+      throw new Error(
+        `${failures.length} light-mode pair(s) below WCAG minimum:\n  ${failures.join(
+          "\n  ",
+        )}`,
+      );
+    }
+  });
+
+  it("each dark-mode pair clears its declared WCAG minimum", () => {
+    const failures = darkPairs
+      .map((pair) => {
+        const ratio = contrastRatio(pair.fg, pair.bg);
+        return ratio < pair.minRatio
+          ? `${pair.description}: ${pair.fg} on ${pair.bg} = ${ratio.toFixed(
+              2,
+            )}:1 (need ${pair.minRatio.toFixed(1)}:1)`
+          : null;
+      })
+      .filter((m): m is string => m !== null);
+    if (failures.length > 0) {
+      throw new Error(
+        `${failures.length} dark-mode pair(s) below WCAG minimum:\n  ${failures.join(
+          "\n  ",
+        )}`,
+      );
+    }
+  });
+});

--- a/src/app/(protected)/survey/new/page.tsx
+++ b/src/app/(protected)/survey/new/page.tsx
@@ -236,7 +236,7 @@ export default function NewSurveyPage() {
             <Label htmlFor="question">Your question or statement</Label>
             <textarea
               id="question"
-              className="w-full min-h-28 p-4 border border-amber-900/10 rounded-xl resize-none bg-white/80 text-base leading-relaxed placeholder:text-muted-foreground/50 focus:outline-hidden focus:ring-2 focus:ring-amber-500/30 focus:border-amber-300 transition-all duration-200 dark:bg-amber-950/20 dark:border-amber-100/10 dark:focus:ring-amber-500/30 dark:focus:border-amber-700"
+              className="w-full min-h-28 p-4 border border-[var(--color-border-strong)] rounded-xl resize-none bg-white/80 text-base leading-relaxed placeholder:text-muted-foreground/50 focus:outline-hidden focus:ring-2 focus:ring-amber-500/30 focus:border-amber-300 transition-all duration-200 dark:bg-amber-950/20 dark:border-[var(--color-border-strong)] dark:focus:ring-amber-500/30 dark:focus:border-amber-700"
               placeholder="e.g., I support increasing the minimum wage to $15/hour"
               value={question}
               onChange={(e) => setQuestion(e.target.value)}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@
   --font-serif: var(--font-newsreader), Georgia, 'Times New Roman', serif;
 
   --color-border: hsl(var(--border));
+  --color-border-strong: hsl(var(--border-strong));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
   --color-background: hsl(var(--background));
@@ -56,7 +57,11 @@
     --card-foreground: 30 10% 12%;
     --popover: 40 50% 99%;
     --popover-foreground: 30 10% 12%;
-    --primary: 32 95% 44%;
+    /* Primary: amber. Bumped from L=44% (3.10:1 on bg, fails AA both as link
+       text and as fill behind white text) to L=35% so both
+       `primary` on background and `primary-foreground` (white) on `primary`
+       clear WCAG AA 4.5:1. Asserted in src/__tests__/contrast.test.ts. */
+    --primary: 32 95% 35%;
     --primary-foreground: 40 100% 98%;
     --secondary: 35 30% 95%;
     --secondary-foreground: 30 10% 15%;
@@ -64,11 +69,18 @@
     --muted-foreground: 30 5% 45%;
     --accent: 35 40% 94%;
     --accent-foreground: 30 10% 15%;
-    --destructive: 0 84.2% 60.2%;
+    /* Destructive: red. Bumped from red-500 (0 84.2% 60.2%, 3.61:1 with white)
+       to red-600-equivalent (0 73% 49%) so white-on-destructive clears AA. */
+    --destructive: 0 73% 49%;
     --destructive-foreground: 0 0% 98%;
+    /* `--border` is decorative (1.28:1 on bg — fine for hairlines, fails
+       SC 1.4.11 for interactive boundaries). Use `--border-strong` on form
+       inputs, dividers between actionable regions, and any border whose
+       absence would prevent perceiving the control. */
     --border: 35 15% 88%;
+    --border-strong: 35 15% 50%;
     --input: 35 15% 88%;
-    --ring: 32 95% 44%;
+    --ring: 32 95% 35%;
     --radius: 0.625rem;
   }
 
@@ -87,9 +99,15 @@
     --muted-foreground: 30 8% 55%;
     --accent: 30 10% 14%;
     --accent-foreground: 35 20% 95%;
-    --destructive: 0 62.8% 30.6%;
+    /* Dark destructive: was 0 62.8% 30.6% (#7f1d1d, 1.91:1 on dark bg —
+       fails SC 1.4.11 as a non-text indicator and only 9.6:1 for white-on-it,
+       which masks how dim the surface is). Aligned to red-600 hue at L=50%
+       so white-on-destructive stays well above AA and the surface itself
+       clears 3:1 against dark bg. */
+    --destructive: 0 73% 50%;
     --destructive-foreground: 0 0% 98%;
     --border: 30 8% 18%;
+    --border-strong: 30 8% 45%;
     --input: 30 8% 18%;
     --ring: 38 92% 50%;
   }

--- a/src/components/survey/hero-survey-form.tsx
+++ b/src/components/survey/hero-survey-form.tsx
@@ -141,7 +141,7 @@ export function HeroSurveyForm() {
             <textarea
               id={questionId}
               ref={textareaRef}
-              className="min-h-28 w-full resize-none rounded-2xl border border-amber-900/10 bg-background/80 p-4 text-base leading-relaxed placeholder:text-muted-foreground/50 transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-amber-500/30 focus:border-amber-300 dark:border-amber-100/10 dark:bg-amber-950/20 dark:focus:border-amber-700 dark:focus:ring-amber-500/30"
+              className="min-h-28 w-full resize-none rounded-2xl border border-[var(--color-border-strong)] bg-background/80 p-4 text-base leading-relaxed placeholder:text-muted-foreground/50 transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-amber-500/30 focus:border-amber-300 dark:border-[var(--color-border-strong)] dark:bg-amber-950/20 dark:focus:border-amber-700 dark:focus:ring-amber-500/30"
               placeholder="e.g., I support increasing the minimum wage to $15/hour"
               value={question}
               disabled={loading}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,7 +7,11 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-amber-900/10 bg-white/80 px-3 py-2 text-base shadow-warm-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-amber-500/30 focus-visible:border-amber-300 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-amber-100/10 dark:bg-amber-950/20 dark:placeholder:text-amber-100/30 dark:focus-visible:ring-amber-500/30 dark:focus-visible:border-amber-700",
+          // Form input border uses --color-border-strong (SC 1.4.11 ≥3:1
+          // against the input fill). The `--border` token at /10 opacity is
+          // decorative — it failed 1.4.11 because a user with low vision
+          // cannot perceive the input's edge against the page.
+          "flex h-10 w-full rounded-lg border border-[var(--color-border-strong)] bg-white/80 px-3 py-2 text-base shadow-warm-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-amber-500/30 focus-visible:border-amber-300 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-[var(--color-border-strong)] dark:bg-amber-950/20 dark:placeholder:text-amber-100/30 dark:focus-visible:ring-amber-500/30 dark:focus-visible:border-amber-700",
           className
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -16,7 +16,9 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between whitespace-nowrap rounded-lg border border-amber-900/10 bg-white/80 px-3 py-2 text-sm shadow-warm-sm transition-all duration-200 placeholder:text-muted-foreground/60 focus:outline-hidden focus:ring-2 focus:ring-amber-500/30 focus:border-amber-300 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-amber-100/10 dark:bg-amber-950/20 dark:placeholder:text-amber-100/30 dark:focus:ring-amber-500/30 dark:focus:border-amber-700",
+      // Select trigger is an interactive boundary; uses --color-border-strong
+      // (SC 1.4.11 ≥3:1) instead of decorative `--border`.
+      "flex h-10 w-full items-center justify-between whitespace-nowrap rounded-lg border border-[var(--color-border-strong)] bg-white/80 px-3 py-2 text-sm shadow-warm-sm transition-all duration-200 placeholder:text-muted-foreground/60 focus:outline-hidden focus:ring-2 focus:ring-amber-500/30 focus:border-amber-300 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-[var(--color-border-strong)] dark:bg-amber-950/20 dark:placeholder:text-amber-100/30 dark:focus:ring-amber-500/30 dark:focus:border-amber-700",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary

Four token-level contrast pairs in `src/app/globals.css` fell below WCAG AA. Bumped only as much as needed to clear the threshold; brand identity (warm amber, semantic red) stays intact.

| Token (was -> now) | Pair | Before | After | Bound |
|---|---|---|---|---|
| `--primary` 32 95% **44 -> 35**% | primary on bg (link text) | 3.10 | 4.65 | 4.5 |
| `--primary-foreground` on `--primary` | white on amber | 3.08 | 4.62 | 4.5 |
| `--destructive` 0 84.2 60.2 -> **0 73 49** | white on red | 3.61 | 4.82 | 4.5 |
| dark `--destructive` 0 62.8 30.6 -> **0 73 50** | red surface on dark bg | 1.91 | 3.94 | 3.0 |
| `--border-strong` (new) light/dark 35 15 50 / 30 8 45 | input border on bg | 1.28 | 3.62 / 4.11 | 3.0 |

`--ring` follows `--primary` (used for focus indicators, SC 1.4.11).

## What changed

- `src/app/globals.css` - new HSL values, `--border-strong` added under `:root` and `.dark`, exposed as `--color-border-strong` in `@theme`. Inline comments document the rationale at each bumped token.
- `src/components/ui/input.tsx`, `src/components/ui/select.tsx`, `src/components/survey/hero-survey-form.tsx`, `src/app/(protected)/survey/new/page.tsx` - swapped form-control borders from `border-amber-900/10` (1.18:1) to `border-[var(--color-border-strong)]`. Decorative borders untouched.
- `src/__tests__/contrast.test.ts` - asserts every documented light- and dark-mode pair clears its declared WCAG minimum. Failure prints which pair drifted and to what ratio.
- `.github/workflows/ci.yml` - added `pnpm test` step so the contrast assertions gate merges.

## Out of scope

`Button.tsx` hardcodes `bg-amber-600 text-white` (3.19:1) and `bg-red-500 text-white` (3.76:1) directly rather than consuming `--primary` / `--destructive`. The audit was scoped to design tokens; the Button utility classes are a separate fix and not addressed here.

## Test plan

- [x] `pnpm test` -> 73 passed (4 new contrast cases)
- [x] `pnpm typecheck` -> clean
- [x] `pnpm lint` -> clean
- [x] `pnpm build` -> clean
- [ ] CI green (typecheck + lint + test + build)

Generated with [Claude Code](https://claude.com/claude-code)
